### PR TITLE
feat: add the ability to select whether the SFTP service is public facing or private inside a VPC

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,14 +23,15 @@ This script builds an AWS Transfer Family server that is backed by an S3 bucket:
 
 ## Inputs
 
-| Name                                                                                                                              | Description                                                        | Type  | Default | Required |
-| --------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------ | ----- | ------- | :------: |
-| <a name="input_aws_region"></a> [aws\_region](#input\_aws\_region)                                                                | AWS region to install the Transfer Server (SFTP server) into       | `any` | n/a     |   yes    |
-| <a name="input_aws_region"></a> [aws\_region](#input\_aws\_region)                                                                | AWS region to install the Transfer Server (SFTP server) into       | `any` | n/a     |   yes    |
-| <a name="input_transfer_server_name"></a> [transfer\_server\_name](#input\_transfer\_server\_name)                                | The name to be given the the transfer server                       | `any` | n/a     |   yes    |
-| <a name="input_transfer_s3_bucket_name"></a> [transfer\_server\_s3\_bucket\_name](#input\_transfer\_server\_s3\_bucket\_name)     | The name of the S3 bucket supplying storage to the transfer server | `any` | n/a     |   yes    |
-| <a name="input_transfer_server_write_users"></a> [transfer\_server\_write_users](#input\_transfer\_server\_write\_users)          | A list of users with write access in the format listed below       | `any` | n/a     |   yes    |
-| <a name="input_transfer_server_readonly_users"></a> [transfer\_server\_readonly_users](#input\_transfer\_server\_readonly\_users) | A list of users with readonly access in the format listed below    | `any` | n/a     |   yes    |
+| Name                                                                                                                              | Description                                                        | Type      | Default  | Required |
+| --------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------ | --------- | -------- | :------: |
+| <a name="input_aws_region"></a> [aws\_region](#input\_aws\_region)                                                                | AWS region to install the Transfer Server (SFTP server) into       | `any`     |  n/a     |   yes    |
+| <a name="input_aws_vpc_id"></a> [aws\_vpc\_id](#input\_aws\_vpc_id)                                                               | The VPC id of the VPC to install Transfer  Server into             | `any`     |  n/a     |   yes    |
+| <a name="input_transfer_endpoint_type"></a> [transfer\_endpoint\_type](#input\_transfer\_endpoint\_type)                          | `PUBLIC` or `VPC`. Defaults to `PUBLIC`.                           | `any`     | `PUBLIC` |   no     |
+| <a name="input_transfer_server_name"></a> [transfer\_server\_name](#input\_transfer\_server\_name)                                | The name to be given the the Transfer Server                       | `any`     |  n/a     |   yes    |
+| <a name="input_transfer_s3_bucket_name"></a> [transfer\_server\_s3\_bucket\_name](#input\_transfer\_server\_s3\_bucket\_name)     | The name of the S3 bucket supplying storage to the Transfer Server | `any`     |  n/a     |   yes    |
+| <a name="input_transfer_server_write_users"></a> [transfer\_server\_write_users](#input\_transfer\_server\_write\_users)          | A list of users with write access in the format listed below       | `any`     | `[]`     |   yes    |
+| <a name="input_transfer_server_readonly_users"></a> [transfer\_server\_readonly_users](#input\_transfer\_server\_readonly\_users) | A list of users with readonly access in the format listed below    | `any`     | `[]`     |   yes    |
 
 
 ### Example of transfer_server_write_users and terraform_server_readonly_users:
@@ -66,6 +67,6 @@ transfer_server_readonly_users = [
 
 | Name                                                                                                                                    | Description                                      |
 | --------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------ |
-| <a name="transfer_server_arn"><a> [transfer\_server\_arn](#transfer\_server\_arn) The Amazon Resource Name (ARN) of the transfer server |
+| <a name="transfer_server_arn"><a> [transfer\_server\_arn](#transfer\_server\_arn)                                                       | The Amazon Resource Name (ARN) of the transfer server |
 | <a name="transfer_server_id"></a> [transfer\_server\_id](#transfer\_server\_id)                                                         | The Terraform id of the transfer server resource |
 | <a name="transfer_server_endpoint"></a> [transfer\_server\_endpoint](#transfer\_server\_endpoint)                                       | The endpoint (URI) of the transfer server        |

--- a/remote-backend-example-with-vpc.tf.example
+++ b/remote-backend-example-with-vpc.tf.example
@@ -20,13 +20,23 @@ provider "aws" {
   region = var.aws_region
 }
 
+module "vpc" {
+  source          = "github.com/honestbank/terraform-aws-vpc"
+  name            = "sftp-vpc"
+  cidr            = "10.125.0.0/16"
+  azs             = ["ap-southeast-1a"]
+  public_subnets  = ["10.125.0.0/19"]
+  private_subnets = ["10.125.32.0/19"]
+}
+
 module "sftp" {
   source                         = "./sftp"
-  transfer_endpoint_type         = var.transfer_endpoint_type
+  transfer_endpoint_type         = "VPC"
   transfer_server_name           = var.transfer_server_name
   transfer_server_s3_bucket_name = var.transfer_server_s3_bucket_name
-  transfer_server_subnet_ids     = []
-  transfer_server_vpc_id         = ""
+  transfer_server_subnet_ids     = module.vpc.private_subnets
+  transfer_server_vpc_id         = module.vpc.vpc_id
   transfer_server_write_users    = var.transfer_server_write_users
   transfer_server_readonly_users = var.transfer_server_readonly_users
+  depends_on                     = [module.vpc]
 }

--- a/sftp/outputs.tf
+++ b/sftp/outputs.tf
@@ -1,11 +1,11 @@
 output "transfer_server_arn" {
-  value = aws_transfer_server.transfer_server.arn
+  value = var.transfer_endpoint_type == "PUBLIC" ? aws_transfer_server.transfer_server[0].arn : aws_transfer_server.transfer_server_private[0].arn
 }
 
 output "transfer_server_id" {
-  value = aws_transfer_server.transfer_server.id
+  value = var.transfer_endpoint_type == "PUBLIC" ? aws_transfer_server.transfer_server[0].id : aws_transfer_server.transfer_server_private[0].id
 }
 
 output "transfer_server_endpoint" {
-  value = aws_transfer_server.transfer_server.endpoint
+  value = var.transfer_endpoint_type == "PUBLIC" ? aws_transfer_server.transfer_server[0].endpoint : aws_transfer_server.transfer_server_private[0].endpoint
 }

--- a/sftp/sftp.tf
+++ b/sftp/sftp.tf
@@ -34,26 +34,59 @@ resource "aws_s3_bucket" "transfer_server_bucket" {
 }
 
 resource "aws_transfer_server" "transfer_server" {
+  count                  = var.transfer_endpoint_type == "PUBLIC" ? 1 : 0
   identity_provider_type = "SERVICE_MANAGED"
   logging_role           = aws_iam_role.transfer_server_role.arn
   protocols              = ["SFTP"]
+  endpoint_type          = var.transfer_endpoint_type
   tags = {
     type = "Managed by Terraform"
   }
 }
 
-resource "aws_transfer_ssh_key" "transfer_server_readonly_ssh_keys" {
-  count = length(var.transfer_server_readonly_users)
+resource "aws_transfer_server" "transfer_server_private" {
+  count                  = var.transfer_endpoint_type == "VPC" ? 1 : 0
+  identity_provider_type = "SERVICE_MANAGED"
+  logging_role           = aws_iam_role.transfer_server_role.arn
+  protocols              = ["SFTP"]
+  endpoint_type          = var.transfer_endpoint_type
+  endpoint_details {
+    subnet_ids = var.transfer_server_subnet_ids
+    vpc_id     = var.transfer_server_vpc_id
+  }
 
-  server_id = aws_transfer_server.transfer_server.id
-  user_name = element(aws_transfer_user.transfer_server_readonly_user.*.user_name, count.index)
+  tags = {
+    type = "Managed by Terraform"
+  }
+}
+
+## PUBLIC SERVER
+resource "aws_transfer_ssh_key" "transfer_server_readonly_ssh_keys_public" {
+  count     = var.transfer_endpoint_type == "PUBLIC" ? length(var.transfer_server_readonly_users) : 0
+  server_id = aws_transfer_server.transfer_server[0].id
+  user_name = element(aws_transfer_user.transfer_server_readonly_user_public.*.user_name, count.index)
   body      = var.transfer_server_readonly_users[count.index].ssh_key
 }
 
-resource "aws_transfer_ssh_key" "transfer_server_write_ssh_keys" {
-  count = length(var.transfer_server_write_users)
+resource "aws_transfer_ssh_key" "transfer_server_write_ssh_keys_public" {
+  count = var.transfer_endpoint_type == "PUBLIC" ? length(var.transfer_server_write_users) : 0
 
-  server_id = aws_transfer_server.transfer_server.id
-  user_name = element(aws_transfer_user.transfer_server_write_user.*.user_name, count.index)
+  server_id = aws_transfer_server.transfer_server[0].id
+  user_name = element(aws_transfer_user.transfer_server_write_user_public.*.user_name, count.index)
+  body      = var.transfer_server_write_users[count.index].ssh_key
+}
+
+## PRIVATE SERVER
+resource "aws_transfer_ssh_key" "transfer_server_readonly_ssh_keys_private" {
+  count     = var.transfer_endpoint_type == "VPC" ? length(var.transfer_server_readonly_users) : 0
+  server_id = aws_transfer_server.transfer_server_private[0].id
+  user_name = element(aws_transfer_user.transfer_server_readonly_user_private.*.user_name, count.index)
+  body      = var.transfer_server_readonly_users[count.index].ssh_key
+}
+
+resource "aws_transfer_ssh_key" "transfer_server_write_ssh_keys_private" {
+  count     = var.transfer_endpoint_type == "VPC" ? length(var.transfer_server_write_users) : 0
+  server_id = aws_transfer_server.transfer_server_private[0].id
+  user_name = element(aws_transfer_user.transfer_server_write_user_private.*.user_name, count.index)
   body      = var.transfer_server_write_users[count.index].ssh_key
 }

--- a/sftp/users.tf
+++ b/sftp/users.tf
@@ -1,7 +1,8 @@
-resource "aws_transfer_user" "transfer_server_readonly_user" {
-  count = length(var.transfer_server_readonly_users)
+## PUBLIC SERVER
+resource "aws_transfer_user" "transfer_server_readonly_user_public" {
+  count = var.transfer_endpoint_type == "PUBLIC" ? length(var.transfer_server_readonly_users) : 0
 
-  server_id           = aws_transfer_server.transfer_server.id
+  server_id           = aws_transfer_server.transfer_server[0].id
   user_name           = var.transfer_server_readonly_users[count.index].user_name
   role                = aws_iam_role.transfer_server_readonly_role.arn
   home_directory_type = "LOGICAL"
@@ -11,10 +12,37 @@ resource "aws_transfer_user" "transfer_server_readonly_user" {
   }
 }
 
-resource "aws_transfer_user" "transfer_server_write_user" {
-  count = length(var.transfer_server_write_users)
+resource "aws_transfer_user" "transfer_server_write_user_public" {
+  count = var.transfer_endpoint_type == "PUBLIC" ? length(var.transfer_server_write_users) : 0
 
-  server_id           = aws_transfer_server.transfer_server.id
+  server_id           = aws_transfer_server.transfer_server[0].id
+  user_name           = var.transfer_server_write_users[count.index].user_name
+  role                = aws_iam_role.transfer_server_write_role.arn
+  home_directory_type = "LOGICAL"
+  home_directory_mappings {
+    entry  = "/"
+    target = "/${aws_s3_bucket.transfer_server_bucket.id}/${var.transfer_server_write_users[count.index].home_directory}"
+  }
+}
+
+## PRIVATE SERVER
+resource "aws_transfer_user" "transfer_server_readonly_user_private" {
+  count = var.transfer_endpoint_type == "VPC" ? length(var.transfer_server_readonly_users) : 0
+
+  server_id           = aws_transfer_server.transfer_server_private[0].id
+  user_name           = var.transfer_server_readonly_users[count.index].user_name
+  role                = aws_iam_role.transfer_server_readonly_role.arn
+  home_directory_type = "LOGICAL"
+  home_directory_mappings {
+    entry  = "/"
+    target = "/${aws_s3_bucket.transfer_server_bucket.id}/${var.transfer_server_readonly_users[count.index].home_directory}"
+  }
+}
+
+resource "aws_transfer_user" "transfer_server_write_user_private" {
+  count = var.transfer_endpoint_type == "VPC" ? length(var.transfer_server_write_users) : 0
+
+  server_id           = aws_transfer_server.transfer_server_private[0].id
   user_name           = var.transfer_server_write_users[count.index].user_name
   role                = aws_iam_role.transfer_server_write_role.arn
   home_directory_type = "LOGICAL"

--- a/sftp/variables.tf
+++ b/sftp/variables.tf
@@ -3,6 +3,15 @@ variable "transfer_server_name" {
   description = "The name to apply to the transfer server i.e: Example's SFTP server"
 }
 
+variable "transfer_endpoint_details" {
+  type    = list(any)
+  default = []
+}
+variable "transfer_endpoint_type" {
+  type        = string
+  description = "Used to set the SFTP server to a public or private (inside VPC) deployment"
+}
+
 variable "transfer_server_s3_bucket_name" {
   type        = string
   description = "The name to apply to the transfer server's s3 storage bucket"
@@ -14,8 +23,18 @@ variable "transfer_server_readonly_users" {
   default     = []
 }
 
+variable "transfer_server_subnet_ids" {
+  type    = list(any)
+  default = []
+}
+
 variable "transfer_server_write_users" {
   type        = list(any)
   description = "list of user objects for users with write access"
   default     = []
+}
+
+variable "transfer_server_vpc_id" {
+  type    = string
+  default = ""
 }

--- a/test/aws-sftp_test.go
+++ b/test/aws-sftp_test.go
@@ -20,6 +20,7 @@ func TestTerraformAwsTransfer(t *testing.T) {
 	terraformOptions := terraform.WithDefaultRetryableErrors(t, &terraform.Options{
 		TerraformDir: workingDir,
 		Vars: map[string]interface{}{
+			"transfer_endpoint_type":	"PUBLIC",
 			"transfer_server_name":           "terratest-sftp-server-terratest",
 			"transfer_server_s3_bucket_name": name,
 			"transfer_server_write_users": []map[string]interface{}{

--- a/test/aws-sftp_test.go
+++ b/test/aws-sftp_test.go
@@ -20,7 +20,7 @@ func TestTerraformAwsTransfer(t *testing.T) {
 	terraformOptions := terraform.WithDefaultRetryableErrors(t, &terraform.Options{
 		TerraformDir: workingDir,
 		Vars: map[string]interface{}{
-			"transfer_server_name":           "terratest-sftp-server",
+			"transfer_server_name":           "terratest-sftp-server-terratest",
 			"transfer_server_s3_bucket_name": name,
 			"transfer_server_write_users": []map[string]interface{}{
 				{

--- a/variables.tf
+++ b/variables.tf
@@ -3,6 +3,17 @@ variable "aws_region" {
   description = "The AWS Region in which to provision the managed SFTP service + S3 buckets"
 }
 
+variable "transfer_endpoint_type" {
+  type        = string
+  description = "Used to set the SFTP server to a public or private (inside VPC) deployment"
+  default     = "PUBLIC"
+}
+
+variable "transfer_endpoint_details" {
+  type    = list(any)
+  default = []
+}
+
 variable "transfer_server_name" {
   type        = string
   description = "The name to apply to the transfer server i.e: Example's SFTP server"
@@ -19,8 +30,18 @@ variable "transfer_server_readonly_users" {
   default     = []
 }
 
+variable "transfer_server_subnet_ids" {
+  type    = list(any)
+  default = []
+}
+
 variable "transfer_server_write_users" {
   type        = list(any)
   description = "list of user objects for users with write access"
   default     = []
+}
+
+variable "transfer_server_vpc_id" {
+  type    = string
+  default = ""
 }


### PR DESCRIPTION
<!--
# Pull Request Instructions

* All PRs should reference an issue in our issue tracker. If one doesn't exist, please create one!
* PR titles should follow https://www.conventionalcommits.org.
-->

### Description

* Refactored the SFTP module to allow for the selection of either `PUBLIC` (directly internet facing with a AWS generated DNS name by default) SFTP instance, or a `VPC` instance (installed inside a Private Subnet in a VPC)

The private functionality requires the use of the terraform-aws-vpc module (or any other code blocks or modules that create a VPC and pass the `private subnets` and `vpc id` as outputs for this module to consume.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/honestbank/terraform-aws-sftp/5)
<!-- Reviewable:end -->
