### PR TITLE
chore: rename roles and target bucket

### DIFF
--- a/.github/workflows/terratest.yml
+++ b/.github/workflows/terratest.yml
@@ -44,7 +44,8 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
+          semantic_version: 18
           extra_plugins: |
-            @semantic-release/git@7.0.18
-            @semantic-release/exec@3.3.8
-            @semantic-release/changelog@3.0.0
+            @semantic-release/git@10.0.1
+            @semantic-release/exec@6.0.2
+            @semantic-release/changelog@6.0.1

--- a/sftp/iam.tf
+++ b/sftp/iam.tf
@@ -4,7 +4,7 @@
 
 # Assume Role
 data "aws_iam_policy_document" "transfer_server_assume_role" {
-  provider      = aws.source
+  provider = aws.source
   statement {
     effect  = "Allow"
     actions = ["sts:AssumeRole"]
@@ -17,14 +17,14 @@ data "aws_iam_policy_document" "transfer_server_assume_role" {
 
 # Transfer server role
 resource "aws_iam_role" "transfer_server_role" {
-  provider      = aws.source
-  name               = "${var.transfer_server_name}-transfer_server_role"
+  provider           = aws.source
+  name               = "${var.transfer_server_name}-transfer_server_role-${local.suffix}"
   assume_role_policy = data.aws_iam_policy_document.transfer_server_assume_role.json
 }
 
 # Policy for Users with write access
 data "aws_iam_policy_document" "transfer_server_write_policy_document" {
-  provider      = aws.source
+  provider = aws.source
   statement {
     effect = "Allow"
 
@@ -47,14 +47,14 @@ data "aws_iam_policy_document" "transfer_server_write_policy_document" {
 
 # Role for Users with write access
 resource "aws_iam_role" "transfer_server_write_role" {
-  provider      = aws.source
-  name               = "${var.transfer_server_name}-write-role"
+  provider           = aws.source
+  name               = "${var.transfer_server_name}-write-role-${local.suffix}"
   assume_role_policy = data.aws_iam_policy_document.transfer_server_assume_role.json
 }
 
 # Policy for Users with read-only access
 data "aws_iam_policy_document" "transfer_server_readonly_policy_document" {
-  provider      = aws.source
+  provider = aws.source
   statement {
     effect = "Allow"
 
@@ -74,28 +74,28 @@ data "aws_iam_policy_document" "transfer_server_readonly_policy_document" {
 
 # Role for Users with readonly access
 resource "aws_iam_role" "transfer_server_readonly_role" {
-  provider      = aws.source
-  name               = "${var.transfer_server_name}-readonly-role"
+  provider           = aws.source
+  name               = "${var.transfer_server_name}-readonly-role-${local.suffix}"
   assume_role_policy = data.aws_iam_policy_document.transfer_server_assume_role.json
 }
 
 # Map write policy to write enabled Users
 resource "aws_iam_role_policy" "transfer_server_write_policy" {
-  provider      = aws.source
-  name   = "${var.transfer_server_name}-transfer_server_write_policy"
-  role   = aws_iam_role.transfer_server_write_role.name
-  policy = data.aws_iam_policy_document.transfer_server_write_policy_document.json
+  provider = aws.source
+  name     = "${var.transfer_server_name}-transfer_server_write_policy-${local.suffix}"
+  role     = aws_iam_role.transfer_server_write_role.name
+  policy   = data.aws_iam_policy_document.transfer_server_write_policy_document.json
 }
 
 resource "aws_iam_role_policy" "transfer_server_readonly_policy" {
-  provider      = aws.source
-  name   = "${var.transfer_server_name}-transfer_server_readonly_policy"
-  role   = aws_iam_role.transfer_server_readonly_role.name
-  policy = data.aws_iam_policy_document.transfer_server_readonly_policy_document.json
+  provider = aws.source
+  name     = "${var.transfer_server_name}-transfer_server_readonly_policy-${local.suffix}"
+  role     = aws_iam_role.transfer_server_readonly_role.name
+  policy   = data.aws_iam_policy_document.transfer_server_readonly_policy_document.json
 }
 
 data "aws_iam_policy_document" "transfer_server_to_cloudwatch_assume_policy" {
-  provider      = aws.source
+  provider = aws.source
   statement {
     effect = "Allow"
 
@@ -110,16 +110,16 @@ data "aws_iam_policy_document" "transfer_server_to_cloudwatch_assume_policy" {
 }
 
 resource "aws_iam_role_policy" "transfer_server_to_cloudwatch_policy" {
-  provider      = aws.source
-  name   = "${var.transfer_server_name}-transfer_server_to_cloudwatch_policy"
-  role   = aws_iam_role.transfer_server_role.name
-  policy = data.aws_iam_policy_document.transfer_server_to_cloudwatch_assume_policy.json
+  provider = aws.source
+  name     = "${var.transfer_server_name}-transfer_server_to_cloudwatch_policy-${local.suffix}"
+  role     = aws_iam_role.transfer_server_role.name
+  policy   = data.aws_iam_policy_document.transfer_server_to_cloudwatch_assume_policy.json
 }
 
 # Replication policy for S3 to S3 replication
 resource "aws_iam_role" "replication" {
-  provider      = aws.source
-  name = "sftp-replication-role"
+  provider = aws.source
+  name     = "sftp-replication-role-${local.suffix}"
 
   assume_role_policy = <<POLICY
 {
@@ -139,8 +139,8 @@ POLICY
 }
 
 resource "aws_iam_policy" "replication" {
-  provider      = aws.source
-  name = "sftp-replication-policy"
+  provider = aws.source
+  name     = "sftp-replication-policy-${local.suffix}"
 
   policy = <<POLICY
 {
@@ -178,4 +178,16 @@ resource "aws_iam_policy" "replication" {
   ]
 }
 POLICY
+}
+
+locals {
+  suffix = random_string.iam_role_random_suffix.result
+}
+
+resource "random_string" "iam_role_random_suffix" {
+  length  = 4
+  upper   = false
+  lower   = true
+  number  = true
+  special = false
 }


### PR DESCRIPTION
<!--
# Pull Request Instructions

* All PRs should reference an issue in our issue tracker. If one doesn't exist, please create one!
* PR titles should follow https://www.conventionalcommits.org.
-->

### Description
This PR proposes two changes:
* The bucket name of the 'replica' bucket is renamed to 'replica' instead of 'target'. We found out while working with this module it is more intuitive to use the word 'replica' than 'target'.
* It adds to roles and policies a randomly generated suffix of 4 lowercase letters. This is just to avoid collisions when deploying this module into the very same subaccount multiple times during local terratest. It does not provide any feature and does not mean the module is intended to be deployed multiple times in the same subaccount. But for terratest it is very convenient.
* It was not part of this PR but formatting has been applied `terraform fmt`
* Updates versions of semantic release in Github workflows

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/honestbank/terraform-aws-sftp/9)
<!-- Reviewable:end -->
