### PR TITLE
chore: extract SFTP VPC endpoint

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -10,6 +10,10 @@ output "transfer_server_endpoint" {
   value = module.sftp.transfer_server_endpoint
 }
 
+output "transfer_server_endpoint_id" {
+  value = module.sftp.transfer_server_endpoint_id
+}
+
 output "transfer_storage_bucket_name" {
   value = module.sftp.transfer_storage_bucket_name
 }

--- a/sftp/outputs.tf
+++ b/sftp/outputs.tf
@@ -1,34 +1,39 @@
 output "transfer_server_arn" {
-  description =  "The Amazon Resource Name (ARN) of the transfer server"
-  value = var.transfer_endpoint_type == "PUBLIC" ? aws_transfer_server.transfer_server[0].arn : aws_transfer_server.transfer_server_private[0].arn
+  description = "The Amazon Resource Name (ARN) of the transfer server"
+  value       = var.transfer_endpoint_type == "PUBLIC" ? aws_transfer_server.transfer_server[0].arn : aws_transfer_server.transfer_server_private[0].arn
 }
 
 output "transfer_server_id" {
-  description =  "The terraform ID of the transfer server"
-  value = var.transfer_endpoint_type == "PUBLIC" ? aws_transfer_server.transfer_server[0].id : aws_transfer_server.transfer_server_private[0].id
+  description = "The terraform ID of the transfer server"
+  value       = var.transfer_endpoint_type == "PUBLIC" ? aws_transfer_server.transfer_server[0].id : aws_transfer_server.transfer_server_private[0].id
 }
 
 output "transfer_server_endpoint" {
-  description =  "The endpoint (URI) of the transfer server"
-  value = var.transfer_endpoint_type == "PUBLIC" ? aws_transfer_server.transfer_server[0].endpoint : aws_transfer_server.transfer_server_private[0].endpoint
+  description = "The endpoint (URI) of the transfer server"
+  value       = var.transfer_endpoint_type == "PUBLIC" ? aws_transfer_server.transfer_server[0].endpoint : aws_transfer_server.transfer_server_private[0].endpoint
+}
+
+output "transfer_server_endpoint_id" {
+  description = "ID of the SFTP VPC endpoint"
+  value       = var.transfer_endpoint_type == "VPC" ? aws_vpc_endpoint.sftp_vpc_endpoint[0].id : null
 }
 
 output "transfer_storage_bucket_name" {
-  description =  "The bucket name of transfer storage"
-  value = aws_s3_bucket.transfer_server_bucket.id
+  description = "The bucket name of transfer storage"
+  value       = aws_s3_bucket.transfer_server_bucket.id
 }
 
 output "transfer_storage_bucket_arn" {
-  description =  "The bucket ARN of target storage"
-  value = aws_s3_bucket.transfer_server_bucket.arn
+  description = "The bucket ARN of target storage"
+  value       = aws_s3_bucket.transfer_server_bucket.arn
 }
 
 output "target_storage_bucket_name" {
-  description =  "The bucket name of target storage"
-  value = aws_s3_bucket.target_storage_bucket.id
+  description = "The bucket name of target storage"
+  value       = aws_s3_bucket.target_storage_bucket.id
 }
 
 output "target_storage_bucket_arn" {
-  description =  "The bucket ARN of target storage"
-  value = aws_s3_bucket.target_storage_bucket.arn
+  description = "The bucket ARN of target storage"
+  value       = aws_s3_bucket.target_storage_bucket.arn
 }


### PR DESCRIPTION
<!--
# Pull Request Instructions

* All PRs should reference an issue in our issue tracker. If one doesn't exist, please create one!
* PR titles should follow https://www.conventionalcommits.org.
-->

### Description

* Extracts the VPC endpoint as a separate Terraform resource so that we can pull out its ID. Otherwise we cannot. We need the SFTP VPC endpoint to figure out its network interfaces (and we need that to route traffic and to know IPs).
* Some formatting added with `terraform fmt` 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/honestbank/terraform-aws-sftp/10)
<!-- Reviewable:end -->
